### PR TITLE
Improve HTTPS support for client development

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -12,14 +12,15 @@ node_modules
 dist
 dist-ssr
 dev-dist
+.pnpm-store
 
 # Environment and local settings
 *.local
 .env
 
 # mkcert certificates
-mkcert+1.pem
-mkcert+1-key.pem
+dev-key.pem
+dev.pem
 localhost*.pem
 localhost*-key.pem
 

--- a/client/README.md
+++ b/client/README.md
@@ -1,16 +1,18 @@
 # 🎮 Dojo Game Starter - Frontend Integration Guide
 
-> **Complete React + Dojo integration documentation**  
+> **Complete React + Dojo integration documentation**
 > From zero to onchain game in 5 minutes ⚡
 
 [![Starknet](https://img.shields.io/badge/Starknet-Ready-orange)](https://starknet.io) [![Cairo](https://img.shields.io/badge/Cairo-2.0-blue)](https://cairo-lang.org) [![Dojo](https://img.shields.io/badge/Dojo-ECS-red)](https://dojoengine.org)
 
 ## 🚀 Quick Start
 
+> Controller requires the client to run over HTTPS, so make sure you have the `mkcert` package installed on your system
+
 ```bash
 git clone https://github.com/your-username/dojo-game-starter
 cd dojo-game-starter/client
-npm install && npm run dev
+npm install && npm run mkcert && npm run dev
 ```
 
 **That's it!** Your onchain game is running locally with wallet integration, optimistic updates, and seamless blockchain connectivity.

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "serve": "vite preview",
     "format:check": "prettier --check .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "mkcert": "mkcert -key-file dev-key.pem -cert-file dev.pem localhost"
   },
   "dependencies": {
     "@cartridge/connector": "0.5.9",

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -2,16 +2,16 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import topLevelAwait from "vite-plugin-top-level-await";
 import wasm from "vite-plugin-wasm";
-//import fs from "fs";
+import fs from "fs";
 
 export default defineConfig({
   plugins: [react(), wasm(), topLevelAwait()],
   server: {
     port: 3002,
-    // https: {
-    //   key: fs.readFileSync("mkcert+1-key.pem"),
-    //   cert: fs.readFileSync("mkcert+1.pem"),
-    // },
+    https: {
+      key: fs.readFileSync("dev-key.pem"),
+      cert: fs.readFileSync("dev.pem"),
+    },
   },
   define: {
     global: 'globalThis',

--- a/contract/Scarb.toml
+++ b/contract/Scarb.toml
@@ -17,8 +17,8 @@ achievement = { git = "https://github.com/cartridge-gg/arcade", tag = "v1.2.1" }
 [[target.starknet-contract]]
 build-external-contracts = [
     "dojo::world::world_contract::world",
-    "achievement::events::index::e_TrophyCreation", 
-    "achievement::events::index::e_TrophyProgression", 
+    "achievement::events::index::e_TrophyCreation",
+    "achievement::events::index::e_TrophyProgression",
 ]
 
 [dev-dependencies]


### PR DESCRIPTION
Controller requires HTTPS to connect to the client. This PR makes HTTPS the default behavior for local development.

- Create the local certificate with `npm run mkcert`
- Add the certificate to the Vite config